### PR TITLE
Allow you to specific any executable for redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,30 @@ Profile names for Chrome and Edge can either be the name you see in the profile 
 
 For Chrome, `hosted_domain` can be the name of a Google Apps domain that you've signed in to Chrome, in which case bichrome automatically determines which profile that is.
 
+You may also supply `Executable` as a profile's browser, along with a path to a program you would like to open certain URLs. You could, for example, use it to open YouTube links directly in your video player of choice.
+
+```json
+{
+    "default_profile": "...",
+    "profiles": {
+        "Video Player": {
+            "browser": "Executable",
+            "path": "C:/Program Files/mpv/mpv.exe"
+        }
+    },
+    "profile_selection": [
+        {
+            "profile": "Video Player",
+            "pattern": "*.youtube.com"
+        },
+        {
+            "profile": "Video Player",
+            "pattern": "youtu.be"
+        }
+    ]
+}
+```
+
 [example_config]: example_config/bichrome_config.json
 
 ## License

--- a/example_config/bichrome_config.json
+++ b/example_config/bichrome_config.json
@@ -21,6 +21,10 @@
         "That One Profile For Edge": {
             "browser": "Edge",
             "profile": "Profile 2"
+        },
+        "Video Player": {
+            "browser": "Executable",
+            "path": "C:/Program Files/mpv/mpv.exe"
         }
     },
     "profile_selection": [
@@ -47,6 +51,14 @@
         {
             "profile": "Personal",
             "pattern": "*.github.com"
+        },
+        {
+            "profile": "Video Player",
+            "pattern": "*.youtube.com"
+        },
+        {
+            "profile": "Video Player",
+            "pattern": "youtu.be"
         }
     ]
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,12 +103,12 @@ impl EdgeProfile {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ExecutablePath {
-    path: String,
+    path: PathBuf,
 }
 
 impl ExecutablePath {
     pub fn get_path(&self) -> PathBuf {
-        PathBuf::from(&self.path)
+        self.path.clone()
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use crate::{
     os::get_chrome_local_state_path,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
@@ -102,6 +102,17 @@ impl EdgeProfile {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ExecutablePath {
+    path: String,
+}
+
+impl ExecutablePath {
+    pub fn get_path(&self) -> PathBuf {
+        PathBuf::from(&self.path)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "browser")]
 pub enum Browser {
     Chrome(ChromeProfile),
@@ -109,6 +120,7 @@ pub enum Browser {
     OsDefault,
     Edge(EdgeProfile),
     Safari,
+    Executable(ExecutablePath)
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -104,6 +104,8 @@ fn handle_url(url: &str) -> Result<()> {
         Browser::Edge(_) => {
             bail!("Microsoft Edge not supported on macOS")
         }
+        Browser::Executable(location) =>
+            (location.get_path().to_str().unwrap().to_string(), vec![url.to_string()])
     };
 
     debug!("launching \"{}\" \"{}\"", exe, args.join("\" \""));

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -425,6 +425,7 @@ pub fn main() -> Result<()> {
                     Browser::Safari => {
                         bail!("Apple Safari not supported on Windows")
                     }
+                    Browser::Executable(location) => (location.get_path(), vec![url.to_string()])
                 };
 
                 let commandline = format!("\"{}\" \"{}\"", exe.display(), args.join("\" \""));


### PR DESCRIPTION
I had an idea to write an application that would automatically open links like YouTube in media players so I looked around for ways to set/check default browser in Rust and I found your very well fleshed out project. Good job on this!

I was able to wrench my way in and add support for this feature as well. Here's an example config:
```json
{
    "default_profile": "Firefox",
    "profiles": {
        "Firefox": {
            "browser": "Firefox"
        },
        "mpv": {
            "browser": "Executable",
            "path": "C:/Program Files/mpv/mpv.exe"
        }
    },
    "profile_selection": [
        {
            "profile": "mpv",
            "pattern": "*.youtube.com"
        },
        {
            "profile": "mpv",
            "pattern": "youtu.be"
        }
    ]
}
```
I'm not very experienced with serde, but I managed to make it error out if you forget the path for the executable, even if it's a bit unspecific:
```
cargo run -- --debug https://google.com/
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target\debug\bichrome.exe --debug https://google.com/`
12:31:03 [DEBUG] (1) bichrome::windows: attempting to load config from C:\Users\Linus\Code\bichrome\target\debug\bichrome_config.json
12:31:03 [ERROR] failed to parse config: InvalidJson(Error("missing field `path`", line: 10, column: 5))
```

I don't know if you're interested in having this feature at all, so let me know what your intentions are. I have a MacBook so I could probably write and test the macOS code myself.